### PR TITLE
Remove snippet name trailing space

### DIFF
--- a/src/build-snippets-archive/snippets.js
+++ b/src/build-snippets-archive/snippets.js
@@ -19,7 +19,7 @@ module.exports = function () {
             alfredsnippet: {
                 snippet: emoji.emoji,
                 uid: uuid,
-                name: `${emoji.emoji} ${names} ${tags ? `- ${tags}` : ``}`,
+                name: `${emoji.emoji} ${names}${tags ? ` - ${tags}` : ``}`,
                 keyword: `:${emoji.name}:`
             }
         };

--- a/src/original-vs-new/index.js
+++ b/src/original-vs-new/index.js
@@ -30,7 +30,7 @@ getOriginalSnippets().then(snippets => {
         return {
             name: snippet.alfredsnippet.name,
             snippet: snippet.alfredsnippet.snippet,
-            keyword: snippet.alfredsnippet.keyword.replace(/_/g, ' ').trim(),
+            keyword: snippet.alfredsnippet.keyword.replace(/_/g, ' '),
         }
     })
 


### PR DESCRIPTION
Remove trailing space in snippet name when the emoji has no tags.